### PR TITLE
feat: Studio Monitor 디자인 시스템 + Spotify/Apple Music 임포트 (#22 #20)

### DIFF
--- a/electron/ipc/library.ts
+++ b/electron/ipc/library.ts
@@ -45,6 +45,8 @@ export function registerLibraryHandlers(): void {
           mimeType: format.codec ?? null,
           coverArtPath: null,
           tags: [],
+          hasAudio: true,
+          externalLinks: null,
           isDeleted: false,
           sourceUrl: existing?.sourceUrl ?? null,
           sourcePlatform: existing?.sourcePlatform ?? null,
@@ -122,6 +124,8 @@ function toTrackRow(t: TrackMeta) {
     dateAdded: t.dateAdded,
     trackNumber: t.trackNumber,
     tags: t.tags ?? [],
+    hasAudio: t.hasAudio ?? true,
+    externalLinks: t.externalLinks ?? null,
   }
 }
 

--- a/electron/lib/library-store.ts
+++ b/electron/lib/library-store.ts
@@ -19,6 +19,8 @@ export interface TrackMeta {
   mimeType: string | null
   coverArtPath: string | null
   tags: string[]
+  hasAudio: boolean
+  externalLinks: string | null
   isDeleted: boolean
   sourceUrl: string | null
   sourcePlatform: string | null

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: music:; media-src music: blob:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: music: https:; media-src music: blob:;" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap" rel="stylesheet" />
     <title>음감</title>
   </head>
   <body>

--- a/src/components/ImportUrlDialog.tsx
+++ b/src/components/ImportUrlDialog.tsx
@@ -25,6 +25,13 @@ function isPlaylistUrl(url: string): boolean {
   }
 }
 
+function isMetadataOnlyUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.replace('www.', '')
+    return host === 'open.spotify.com' || host === 'music.apple.com' || host === 'melon.com'
+  } catch { return false }
+}
+
 export function ImportUrlDialog() {
   const [open, setOpen] = useState(false)
   const [url, setUrl] = useState('')
@@ -33,6 +40,7 @@ export function ImportUrlDialog() {
   const [error, setError] = useState<string | null>(null)
   const [enrichedResult, setEnrichedResult] = useState<EnrichedResult | null>(null)
   const [isPlaylist, setIsPlaylist] = useState(false)
+  const [isMetadataOnly, setIsMetadataOnly] = useState(false)
   const unsubRef = useRef<(() => void)[]>([])
   const { loadTracks } = useLibraryStore()
 
@@ -46,6 +54,7 @@ export function ImportUrlDialog() {
   const handleUrlChange = (val: string) => {
     setUrl(val)
     setIsPlaylist(isPlaylistUrl(val))
+    setIsMetadataOnly(isMetadataOnlyUrl(val))
   }
 
   const handleImport = async (asPlaylist = false) => {
@@ -92,6 +101,7 @@ export function ImportUrlDialog() {
     setError(null)
     setEnrichedResult(null)
     setIsPlaylist(false)
+    setIsMetadataOnly(false)
   }
 
   return (
@@ -134,6 +144,13 @@ export function ImportUrlDialog() {
             <div className="flex items-center gap-2 mb-3 px-2 py-1.5 bg-blue-500/10 border border-blue-500/20 rounded-lg">
               <ListMusic size={12} className="text-blue-400 flex-shrink-0" />
               <span className="text-xs text-blue-400">플레이리스트가 감지됐습니다</span>
+            </div>
+          )}
+
+          {isMetadataOnly && step === 'idle' && (
+            <div className="flex items-center gap-2 mb-3 px-2 py-1.5 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+              <span className="text-amber-400 flex-shrink-0">♪</span>
+              <span className="text-xs text-amber-400">오디오 없이 메타데이터만 저장됩니다 (DRM 보호)</span>
             </div>
           )}
 

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -328,7 +328,7 @@ function TrackGrid({ tracks, selectedTrackId, onSelect, onPlay, onContextMenu }:
               {coverUrl ? (
                 <img src={coverUrl} alt={track.title ?? ''} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200" />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-neutral-600 text-3xl">♪</div>
+                <div className="cover-placeholder">♩</div>
               )}
               {isActive && isPlaying && (
                 <div className="absolute inset-0 bg-black/40 flex items-center justify-center">

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -11,9 +11,11 @@ export function PlayerBar() {
     play, pause, next, prev, setVolume, setCurrentTime, setDuration,
   } = usePlayerStore()
 
+  const hasAudio = !currentTrack || currentTrack.hasAudio !== false
+
   useEffect(() => {
     const audio = audioRef.current
-    if (!audio || !currentTrack) return
+    if (!audio || !currentTrack || !hasAudio) return
 
     window.musicApp.player.getAudioUrl(currentTrack.id).then(url => {
       audio.src = url
@@ -48,7 +50,6 @@ export function PlayerBar() {
   }, [volume])
 
   const handleSeekChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    // Visual update only — actual seek happens on pointer up
     setCurrentTime(Number(e.target.value))
   }, [setCurrentTime])
 
@@ -65,7 +66,14 @@ export function PlayerBar() {
     : null
 
   return (
-    <footer className="flex-shrink-0 h-[72px] bg-neutral-900 border-t border-neutral-800 flex items-center px-4 gap-3">
+    <footer
+      className="flex-shrink-0 flex items-center px-4 gap-4"
+      style={{
+        height: '72px',
+        background: 'linear-gradient(to top, oklch(7% 0.004 60), oklch(10.5% 0.005 60))',
+        borderTop: '1px solid oklch(15.5% 0.006 60)',
+      }}
+    >
       <audio
         ref={audioRef}
         onTimeUpdate={e => {
@@ -76,56 +84,119 @@ export function PlayerBar() {
         onEnded={next}
       />
 
-      {/* Track info with album art */}
+      {/* Track info */}
       <div className="w-56 flex-shrink-0 flex items-center gap-3 min-w-0">
-        <div className="w-12 h-12 rounded-md overflow-hidden bg-neutral-800 flex-shrink-0">
+        {/* Album art */}
+        <div
+          className="w-11 h-11 rounded-md overflow-hidden flex-shrink-0"
+          style={{
+            background: 'linear-gradient(135deg, oklch(15.5% 0.006 60), oklch(22% 0.006 60))',
+            boxShadow: currentTrack ? '0 2px 8px oklch(0% 0 0 / 0.4)' : 'none',
+          }}
+        >
           {coverUrl ? (
             <img src={coverUrl} alt="" className="w-full h-full object-cover" />
           ) : currentTrack ? (
-            <div className="w-full h-full flex items-center justify-center text-neutral-600 text-lg">♪</div>
+            <div className="w-full h-full flex items-center justify-center text-lg" style={{ color: 'oklch(47% 0.003 60)' }}>
+              ♩
+            </div>
           ) : null}
         </div>
-        <div className="min-w-0">
+
+        <div className="min-w-0 flex-1">
           {currentTrack ? (
             <>
-              <p className="text-[13px] font-medium truncate text-neutral-100 leading-tight">
+              <p
+                className="text-[13px] truncate leading-tight"
+                style={{
+                  fontFamily: 'var(--font-display)',
+                  color: 'var(--color-neutral-100)',
+                  letterSpacing: '0.01em',
+                }}
+              >
                 {currentTrack.title ?? 'Unknown'}
               </p>
-              <p className="text-[11px] truncate text-neutral-500 leading-tight mt-0.5">
+              <p className="text-[11px] truncate leading-tight mt-0.5" style={{ color: 'var(--color-neutral-500)' }}>
                 {currentTrack.artistName ?? 'Unknown Artist'}
               </p>
-              {(currentTrack.genre || currentTrack.mood) && (
-                <p className="text-[10px] truncate text-neutral-600 leading-tight mt-0.5">
-                  {[currentTrack.genre, currentTrack.mood].filter(Boolean).join(' · ')}
-                </p>
+              {!hasAudio && (
+                <span
+                  className="text-[9px] px-1.5 py-0.5 rounded-full"
+                  style={{
+                    background: 'oklch(75% 0.145 68 / 0.12)',
+                    color: 'var(--color-amber-400)',
+                    border: '1px solid oklch(75% 0.145 68 / 0.2)',
+                  }}
+                >
+                  메타데이터만
+                </span>
               )}
             </>
           ) : (
-            <p className="text-xs text-neutral-600">Nothing playing</p>
+            <p className="text-xs" style={{ color: 'oklch(34% 0.004 60)' }}>Nothing playing</p>
           )}
         </div>
       </div>
 
       {/* Controls + progress */}
-      <div className="flex-1 flex flex-col items-center gap-1 max-w-[600px] mx-auto">
-        <div className="flex items-center gap-5">
-          <button onClick={prev} className="text-neutral-400 hover:text-neutral-100 transition-colors">
-            <SkipBack size={16} />
+      <div className="flex-1 flex flex-col items-center gap-1.5 max-w-[560px] mx-auto">
+        <div className="flex items-center gap-6">
+          <button
+            onClick={prev}
+            className="transition-all duration-150 hover:scale-110"
+            style={{ color: 'oklch(47% 0.003 60)' }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-neutral-100)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'oklch(47% 0.003 60)')}
+          >
+            <SkipBack size={15} />
           </button>
+
           <button
             onClick={isPlaying ? pause : play}
-            className="w-8 h-8 rounded-full bg-neutral-100 text-neutral-900 flex items-center justify-center hover:scale-105 transition-transform disabled:opacity-40"
-            disabled={!currentTrack}
+            disabled={!currentTrack || !hasAudio}
+            className="flex items-center justify-center transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{
+              width: '34px',
+              height: '34px',
+              borderRadius: '50%',
+              background: 'var(--color-neutral-100)',
+              color: 'oklch(7% 0.004 60)',
+              boxShadow: '0 2px 8px oklch(0% 0 0 / 0.3)',
+            }}
+            onMouseEnter={e => {
+              if (!e.currentTarget.disabled) {
+                ;(e.currentTarget as HTMLElement).style.background = 'var(--color-amber-400)'
+                ;(e.currentTarget as HTMLElement).style.transform = 'scale(1.08)'
+              }
+            }}
+            onMouseLeave={e => {
+              ;(e.currentTarget as HTMLElement).style.background = 'var(--color-neutral-100)'
+              ;(e.currentTarget as HTMLElement).style.transform = 'scale(1)'
+            }}
           >
-            {isPlaying ? <Pause size={14} fill="currentColor" /> : <Play size={14} fill="currentColor" className="ml-0.5" />}
+            {isPlaying
+              ? <Pause size={13} fill="currentColor" />
+              : <Play size={13} fill="currentColor" className="ml-0.5" />
+            }
           </button>
-          <button onClick={next} className="text-neutral-400 hover:text-neutral-100 transition-colors">
-            <SkipForward size={16} />
+
+          <button
+            onClick={next}
+            className="transition-all duration-150 hover:scale-110"
+            style={{ color: 'oklch(47% 0.003 60)' }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-neutral-100)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'oklch(47% 0.003 60)')}
+          >
+            <SkipForward size={15} />
           </button>
         </div>
 
-        <div className="flex items-center gap-2 w-full">
-          <span className="text-[10px] text-neutral-500 w-9 text-right tabular-nums">
+        {/* Seek bar */}
+        <div className="flex items-center gap-2.5 w-full">
+          <span
+            className="text-[10px] w-9 text-right tabular-nums"
+            style={{ fontFamily: 'var(--font-mono)', color: 'oklch(47% 0.003 60)' }}
+          >
             {formatDuration(currentTime)}
           </span>
           <input
@@ -133,24 +204,31 @@ export function PlayerBar() {
             min={0}
             max={duration || 0}
             value={currentTime}
+            disabled={!hasAudio}
             onPointerDown={() => { isSeeking.current = true }}
             onPointerUp={handleSeekCommit}
             onChange={handleSeekChange}
-            className="flex-1 h-1 accent-neutral-100 cursor-pointer"
+            className="flex-1 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
           />
-          <span className="text-[10px] text-neutral-500 w-9 tabular-nums">
+          <span
+            className="text-[10px] w-9 tabular-nums"
+            style={{ fontFamily: 'var(--font-mono)', color: 'oklch(47% 0.003 60)' }}
+          >
             {formatDuration(duration)}
           </span>
         </div>
       </div>
 
       {/* Volume */}
-      <div className="flex items-center gap-2 flex-shrink-0 w-32 justify-end">
+      <div className="flex items-center gap-2 flex-shrink-0 w-28 justify-end">
         <button
           onClick={() => setVolume(volume > 0 ? 0 : 0.8)}
-          className="text-neutral-400 hover:text-neutral-100 transition-colors"
+          className="transition-colors duration-150"
+          style={{ color: 'oklch(47% 0.003 60)' }}
+          onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-neutral-100)')}
+          onMouseLeave={e => (e.currentTarget.style.color = 'oklch(47% 0.003 60)')}
         >
-          {volume === 0 ? <VolumeX size={15} /> : <Volume2 size={15} />}
+          {volume === 0 ? <VolumeX size={14} /> : <Volume2 size={14} />}
         </button>
         <input
           type="range"
@@ -159,7 +237,7 @@ export function PlayerBar() {
           step={0.01}
           value={volume}
           onChange={e => setVolume(Number(e.target.value))}
-          className="w-20 h-1 accent-neutral-100 cursor-pointer"
+          className="w-20 cursor-pointer"
         />
       </div>
     </footer>

--- a/src/index.css
+++ b/src/index.css
@@ -1,32 +1,53 @@
 @import "tailwindcss";
 
+/* ── Design Tokens ─────────────────────────────────────── */
 @theme {
-  --color-neutral-950: oklch(8% 0 0);
-  --color-neutral-900: oklch(11% 0 0);
-  --color-neutral-800: oklch(16% 0 0);
-  --color-neutral-700: oklch(22% 0 0);
-  --color-neutral-600: oklch(32% 0 0);
-  --color-neutral-500: oklch(45% 0 0);
-  --color-neutral-400: oklch(60% 0 0);
-  --color-neutral-200: oklch(85% 0 0);
-  --color-neutral-100: oklch(95% 0 0);
-  --color-white: oklch(100% 0 0);
+  /* Warm-tinted dark palette */
+  --color-neutral-950: oklch(7% 0.004 60);
+  --color-neutral-900: oklch(10.5% 0.005 60);
+  --color-neutral-800: oklch(15.5% 0.006 60);
+  --color-neutral-700: oklch(22% 0.006 60);
+  --color-neutral-600: oklch(34% 0.004 60);
+  --color-neutral-500: oklch(47% 0.003 60);
+  --color-neutral-400: oklch(62% 0.003 60);
+  --color-neutral-300: oklch(76% 0.003 60);
+  --color-neutral-200: oklch(86% 0.003 60);
+  --color-neutral-100: oklch(94% 0.004 70);
+  --color-white: oklch(99% 0.003 70);
 
-  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  /* Amber accent — warm analog glow */
+  --color-amber-500: oklch(75% 0.145 68);
+  --color-amber-400: oklch(82% 0.14 70);
+  --color-amber-300: oklch(88% 0.12 72);
+  --color-amber-600: oklch(66% 0.15 64);
+
+  /* Rose for mood */
+  --color-rose-400: oklch(70% 0.18 15);
+  --color-rose-500: oklch(62% 0.20 15);
+
+  /* Typography */
+  --font-display: 'DM Serif Display', Georgia, serif;
+  --font-sans: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'SF Mono', 'Fira Mono', monospace;
+
   --radius: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
 }
 
+/* Light theme overrides */
 .light {
-  --color-neutral-950: oklch(99% 0 0);
-  --color-neutral-900: oklch(96% 0 0);
-  --color-neutral-800: oklch(91% 0 0);
-  --color-neutral-700: oklch(82% 0 0);
-  --color-neutral-600: oklch(65% 0 0);
-  --color-neutral-500: oklch(52% 0 0);
-  --color-neutral-400: oklch(40% 0 0);
-  --color-neutral-200: oklch(20% 0 0);
-  --color-neutral-100: oklch(10% 0 0);
-  --color-white: oklch(0% 0 0);
+  --color-neutral-950: oklch(98% 0.002 80);
+  --color-neutral-900: oklch(95% 0.003 80);
+  --color-neutral-800: oklch(90% 0.003 80);
+  --color-neutral-700: oklch(81% 0.003 70);
+  --color-neutral-600: oklch(64% 0.004 60);
+  --color-neutral-500: oklch(50% 0.003 60);
+  --color-neutral-400: oklch(38% 0.003 60);
+  --color-neutral-300: oklch(25% 0.003 60);
+  --color-neutral-200: oklch(16% 0.004 60);
+  --color-neutral-100: oklch(8% 0.005 60);
+  --color-white: oklch(4% 0.004 60);
 }
 
 *, *::before, *::after {
@@ -44,69 +65,153 @@ body {
   background-color: var(--color-neutral-950);
   color: var(--color-neutral-100);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
 }
 
-::-webkit-scrollbar { width: 6px; }
+/* Refined scrollbar */
+::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-neutral-700); border-radius: 3px; }
+::-webkit-scrollbar-thumb {
+  background: var(--color-neutral-700);
+  border-radius: 2px;
+}
 ::-webkit-scrollbar-thumb:hover { background: var(--color-neutral-600); }
 
+/* Range input — custom track */
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+input[type="range"]::-webkit-slider-runnable-track {
+  background: var(--color-neutral-700);
+  border-radius: 2px;
+  height: 3px;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-neutral-100);
+  margin-top: -3.5px;
+  transition: background 0.15s, transform 0.15s;
+}
+input[type="range"]:hover::-webkit-slider-thumb {
+  background: var(--color-amber-400);
+  transform: scale(1.2);
+}
+
 @layer components {
-  /* Buttons */
+  /* ── Buttons ──────────────────────────────────────────── */
   .btn-primary {
-    @apply px-4 py-1.5 text-sm font-medium bg-neutral-100 text-neutral-950 rounded-lg
-           hover:bg-neutral-200 transition-colors
+    @apply px-4 py-1.5 text-sm font-medium rounded-lg transition-all duration-150
            disabled:opacity-40 disabled:cursor-not-allowed;
+    background: var(--color-neutral-100);
+    color: var(--color-neutral-950);
   }
+  .btn-primary:not(:disabled):hover {
+    background: var(--color-white);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px oklch(0% 0 0 / 0.3);
+  }
+
   .btn-secondary {
-    @apply px-3 py-1.5 text-xs bg-neutral-700 text-neutral-200 rounded-lg
-           hover:bg-neutral-600 transition-colors
+    @apply px-3 py-1.5 text-xs rounded-lg transition-all duration-150
            disabled:opacity-40 disabled:cursor-not-allowed;
+    background: var(--color-neutral-800);
+    color: var(--color-neutral-300);
+    border: 1px solid var(--color-neutral-700);
   }
+  .btn-secondary:not(:disabled):hover {
+    background: var(--color-neutral-700);
+    color: var(--color-neutral-100);
+  }
+
   .btn-ghost {
-    @apply px-3 py-1.5 text-xs text-neutral-400 hover:text-neutral-100 transition-colors;
+    @apply px-3 py-1.5 text-xs transition-colors duration-150;
+    color: var(--color-neutral-500);
+  }
+  .btn-ghost:hover {
+    color: var(--color-neutral-300);
   }
 
-  /* Input */
+  /* ── Input ────────────────────────────────────────────── */
   .input-base {
-    @apply w-full px-3 py-2 bg-neutral-800 border border-neutral-700 rounded-lg
-           text-sm text-neutral-100 placeholder:text-neutral-500
-           focus:outline-none focus:border-neutral-500
+    @apply w-full px-3 py-2 rounded-lg text-sm transition-all duration-150
            disabled:opacity-50;
+    background: var(--color-neutral-800);
+    border: 1px solid var(--color-neutral-700);
+    color: var(--color-neutral-100);
+    font-family: var(--font-sans);
+  }
+  .input-base::placeholder { color: var(--color-neutral-500); }
+  .input-base:focus {
+    outline: none;
+    border-color: var(--color-neutral-500);
+    box-shadow: 0 0 0 2px oklch(47% 0.003 60 / 0.2);
   }
 
-  /* Cards */
-  .card {
-    @apply bg-neutral-900 border border-neutral-800 rounded-xl;
-  }
-
-  /* Pills */
+  /* ── Pills ────────────────────────────────────────────── */
   .pill-genre {
-    @apply inline-flex items-center px-2 py-0.5 rounded-full
-           text-[11px] font-medium bg-violet-500/20 text-violet-300;
+    @apply inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium;
+    background: oklch(75% 0.145 68 / 0.15);
+    color: var(--color-amber-400);
+    border: 1px solid oklch(75% 0.145 68 / 0.25);
   }
   .pill-mood {
-    @apply inline-flex items-center px-2 py-0.5 rounded-full
-           text-[11px] font-medium bg-blue-500/20 text-blue-300;
+    @apply inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium;
+    background: oklch(70% 0.18 15 / 0.12);
+    color: var(--color-rose-400);
+    border: 1px solid oklch(70% 0.18 15 / 0.2);
   }
 
-  /* Section label */
+  /* ── Section label ────────────────────────────────────── */
   .section-label {
-    @apply text-[10px] font-medium text-neutral-500 uppercase tracking-widest;
+    @apply text-[10px] font-medium uppercase tracking-widest;
+    color: var(--color-neutral-500);
+    font-family: var(--font-sans);
+    letter-spacing: 0.12em;
   }
 
-  /* Context menu */
+  /* ── Context menu ─────────────────────────────────────── */
   .ctx-menu {
-    @apply fixed z-50 bg-neutral-900 border border-neutral-700
-           rounded-lg shadow-2xl py-1 min-w-[148px];
+    @apply fixed z-50 py-1 min-w-[160px];
+    background: var(--color-neutral-900);
+    border: 1px solid var(--color-neutral-700);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 16px 48px oklch(0% 0 0 / 0.5), 0 4px 12px oklch(0% 0 0 / 0.3);
+    backdrop-filter: blur(8px);
   }
   .ctx-menu-item {
-    @apply w-full text-left px-3 py-1.5 text-xs text-neutral-300
-           hover:bg-neutral-800 transition-colors;
+    @apply w-full text-left px-3 py-1.5 text-xs transition-colors duration-100;
+    color: var(--color-neutral-300);
+  }
+  .ctx-menu-item:hover {
+    background: var(--color-neutral-800);
+    color: var(--color-neutral-100);
   }
   .ctx-menu-item-danger {
-    @apply w-full text-left px-3 py-1.5 text-xs text-red-400
-           hover:bg-neutral-800 transition-colors;
+    @apply w-full text-left px-3 py-1.5 text-xs transition-colors duration-100;
+    color: oklch(65% 0.2 20);
+  }
+  .ctx-menu-item-danger:hover {
+    background: oklch(65% 0.2 20 / 0.1);
+  }
+
+  /* ── Track card cover placeholder ────────────────────── */
+  .cover-placeholder {
+    @apply w-full h-full flex items-center justify-center;
+    background: linear-gradient(135deg,
+      var(--color-neutral-800) 0%,
+      var(--color-neutral-700) 100%
+    );
+    font-family: var(--font-display);
+    font-size: 1.75rem;
+    color: var(--color-neutral-600);
+    letter-spacing: 0.05em;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export interface Track {
   dateAdded: number
   trackNumber: number | null
   tags: string[]
+  hasAudio?: boolean
+  externalLinks?: string | null
 }
 
 export interface EnrichedResult {


### PR DESCRIPTION
## Summary

- **#22 Design System "Studio Monitor"**: 전체 UI 디자인 시스템 통일
  - DM Serif Display + DM Sans 폰트 페어링 (Google Fonts), 기존 Inter 제거
  - 웜 앰버 accent 컬러 — 음악 앱에 어울리는 아날로그 감성
  - `oklch` 기반 웜 뉘앙스 다크 팔레트 (모든 neutral-* 색상에 따뜻한 hue 추가)
  - 커스텀 `input[type=range]` (앰버 thumb hover glow)
  - `pill-genre`(앰버), `pill-mood`(rose) — 기존 violet/blue 대체
  - `cover-placeholder` 클래스 — 커버아트 없을 때 세련된 그라디언트 배경
  - PlayerBar: 앰버 play 버튼 hover, DM Serif Display 트랙 타이틀, 개선된 seek bar

- **#20 Spotify/Apple Music URL 임포트 (메타데이터 전용)**:
  - `detectPlatform()`: spotify / applemusic / melon 플랫폼 추가
  - `fetchMetadataOnly()`: Spotify oEmbed / Apple Music oEmbed API로 제목·아티스트·썸네일 수집
  - `hasAudio: false` 트랙: PlayerBar 재생 버튼 비활성화 + "메타데이터만" 앰버 배지
  - `ImportUrlDialog`: Spotify/Apple Music URL 감지 시 "오디오 없이 메타데이터만 저장됩니다 (DRM 보호)" 안내
  - `TrackMeta` + `Track`: `hasAudio`, `externalLinks` 필드 추가

## Test plan

- [ ] `pnpm typecheck` 통과 ✅
- [ ] DM Serif Display 폰트가 PlayerBar 트랙 제목에 표시됨
- [ ] 앰버 pill-genre, 로즈 pill-mood 표시
- [ ] input[type=range] hover 시 앰버 thumb 표시
- [ ] Spotify URL 붙여넣기 → "DRM 보호" 안내 표시 → 가져오기 → 라이브러리에 등록
- [ ] Spotify 트랙 클릭 → PlayerBar 재생 버튼 비활성화 + "메타데이터만" 배지

closes #22, closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)