### PR TITLE
fix: 전체 컬러 시스템 amber/rose 통일 — violet/blue 잔재 제거 (#22)

### DIFF
--- a/src/components/ImportUrlDialog.tsx
+++ b/src/components/ImportUrlDialog.tsx
@@ -141,9 +141,9 @@ export function ImportUrlDialog() {
 
           {/* Playlist hint */}
           {isPlaylist && step === 'idle' && (
-            <div className="flex items-center gap-2 mb-3 px-2 py-1.5 bg-blue-500/10 border border-blue-500/20 rounded-lg">
-              <ListMusic size={12} className="text-blue-400 flex-shrink-0" />
-              <span className="text-xs text-blue-400">플레이리스트가 감지됐습니다</span>
+            <div className="flex items-center gap-2 mb-3 px-2 py-1.5 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+              <ListMusic size={12} className="text-amber-400 flex-shrink-0" />
+              <span className="text-xs text-amber-400">플레이리스트가 감지됐습니다</span>
             </div>
           )}
 
@@ -166,7 +166,7 @@ export function ImportUrlDialog() {
                 <div
                   className={`h-full rounded-full transition-all duration-500 ${
                     step === 'ai-searching' || step === 'ai-classifying'
-                      ? 'bg-violet-500 animate-pulse'
+                      ? 'bg-amber-500 animate-pulse'
                       : 'bg-neutral-100'
                   }`}
                   style={{
@@ -186,7 +186,7 @@ export function ImportUrlDialog() {
                   const isCurrent = currentIdx === i
                   return (
                     <div key={s} className="flex items-center gap-1">
-                      <div className={`w-1.5 h-1.5 rounded-full ${isDone ? 'bg-green-500' : isCurrent ? 'bg-violet-500 animate-pulse' : 'bg-neutral-700'}`} />
+                      <div className={`w-1.5 h-1.5 rounded-full ${isDone ? 'bg-green-500' : isCurrent ? 'bg-amber-500 animate-pulse' : 'bg-neutral-700'}`} />
                       <span className={`text-[9px] ${isCurrent ? 'text-neutral-300' : isDone ? 'text-neutral-500' : 'text-neutral-700'}`}>
                         {['다운로드', '파싱', '검색', '분류'][i]}
                       </span>

--- a/src/components/TrackMetadataPanel.tsx
+++ b/src/components/TrackMetadataPanel.tsx
@@ -83,7 +83,7 @@ export function TrackMetadataPanel({ track, onClose, onUpdate, onDelete }: Props
             if (e.key === 'Enter') commitEdit()
             if (e.key === 'Escape') setEditing(null)
           }}
-          className={`${className} bg-neutral-800 rounded px-1 focus:outline-none focus:ring-1 focus:ring-violet-500/60 w-full`}
+          className={`${className} bg-neutral-800 rounded px-1 focus:outline-none focus:ring-1 focus:ring-amber-500/50 w-full`}
         />
       )
     }
@@ -217,7 +217,7 @@ export function TrackMetadataPanel({ track, onClose, onUpdate, onDelete }: Props
         </div>
 
         {aiStep && (
-          <div className="flex items-center gap-2 mb-3 text-xs text-violet-400">
+          <div className="flex items-center gap-2 mb-3 text-xs text-amber-400">
             <Loader2 size={11} className="animate-spin" />
             {aiStep === 'ai-searching' ? '🔍 곡 정보 검색 중…' : '🎵 장르·무드 분류 중…'}
           </div>

--- a/src/components/layout/Dashboard.tsx
+++ b/src/components/layout/Dashboard.tsx
@@ -68,25 +68,31 @@ export function Dashboard() {
 
         {/* Hero: AI Taste Summary */}
         <div
-          className="relative rounded-2xl overflow-hidden bg-gradient-to-br from-violet-950/60 via-indigo-950/50 to-blue-950/40 border border-violet-500/20 p-6"
+          className="relative rounded-2xl overflow-hidden border p-6"
           style={{
-            '--color-neutral-100': 'oklch(95% 0 0)',
-            '--color-neutral-400': 'oklch(60% 0 0)',
-          } as React.CSSProperties}
+            background: 'linear-gradient(135deg, oklch(12% 0.015 70) 0%, oklch(10% 0.01 60) 60%, oklch(9% 0.008 40) 100%)',
+            borderColor: 'oklch(75% 0.145 68 / 0.2)',
+          }}
         >
-          <div className="absolute top-3 right-4 text-violet-500/20 text-5xl select-none leading-none">✦</div>
+          {/* Decorative glow */}
+          <div
+            className="absolute top-0 right-0 w-48 h-48 rounded-full blur-3xl pointer-events-none"
+            style={{ background: 'oklch(75% 0.145 68 / 0.06)' }}
+          />
+          <div className="absolute top-3 right-4 select-none leading-none text-5xl" style={{ color: 'oklch(75% 0.145 68 / 0.12)' }}>♩</div>
+
           <div className="relative">
-            <p className="text-[10px] text-violet-400 uppercase tracking-widest font-medium mb-3 flex items-center gap-1.5">
+            <p className="text-[10px] uppercase tracking-widest font-medium mb-3 flex items-center gap-1.5" style={{ color: 'var(--color-amber-400)' }}>
               <Sparkles size={10} />
               AI 취향 분석
             </p>
             {tasteSummary ? (
-              <p className="text-lg text-neutral-100 leading-relaxed font-light">{tasteSummary}</p>
+              <p className="text-lg text-neutral-100 leading-relaxed font-light" style={{ fontFamily: 'var(--font-display)' }}>{tasteSummary}</p>
             ) : summaryLoading ? (
               <div className="flex items-center gap-2.5">
-                <span className="inline-block w-2 h-2 bg-violet-500 rounded-full animate-pulse" />
-                <span className="inline-block w-2 h-2 bg-violet-500 rounded-full animate-pulse delay-75" />
-                <span className="inline-block w-2 h-2 bg-violet-500 rounded-full animate-pulse delay-150" />
+                <span className="inline-block w-2 h-2 rounded-full animate-pulse" style={{ background: 'var(--color-amber-500)' }} />
+                <span className="inline-block w-2 h-2 rounded-full animate-pulse delay-75" style={{ background: 'var(--color-amber-500)' }} />
+                <span className="inline-block w-2 h-2 rounded-full animate-pulse delay-150" style={{ background: 'var(--color-amber-500)' }} />
                 <span className="text-sm text-neutral-500 ml-1">당신의 취향을 분석하고 있어요…</span>
               </div>
             ) : summaryError ? (
@@ -98,11 +104,18 @@ export function Dashboard() {
                 </p>
                 <button
                   onClick={handleGenerateSummary}
-                  className="flex items-center gap-2 px-4 py-2 rounded-xl bg-violet-600/30 border border-violet-500/40 text-violet-200 text-sm font-medium hover:bg-violet-600/40 transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-colors"
+                  style={{
+                    background: 'oklch(75% 0.145 68 / 0.15)',
+                    border: '1px solid oklch(75% 0.145 68 / 0.3)',
+                    color: 'var(--color-amber-300)',
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = 'oklch(75% 0.145 68 / 0.22)')}
+                  onMouseLeave={e => (e.currentTarget.style.background = 'oklch(75% 0.145 68 / 0.15)')}
                 >
                   <Sparkles size={13} />
                   내 취향 분석하기
-                  <span className="text-[10px] text-violet-400 ml-1">크레딧 1</span>
+                  <span className="text-[10px] ml-1" style={{ color: 'var(--color-amber-500)' }}>크레딧 1</span>
                 </button>
               </div>
             )}
@@ -110,7 +123,10 @@ export function Dashboard() {
               <button
                 onClick={handleGenerateSummary}
                 disabled={summaryLoading}
-                className="mt-4 flex items-center gap-1.5 text-[10px] text-violet-500 hover:text-violet-300 transition-colors disabled:opacity-50"
+                className="mt-4 flex items-center gap-1.5 text-[10px] transition-colors disabled:opacity-50"
+                style={{ color: 'var(--color-amber-500)' }}
+                onMouseEnter={e => (e.currentTarget.style.color = 'var(--color-amber-300)')}
+                onMouseLeave={e => (e.currentTarget.style.color = 'var(--color-amber-500)')}
               >
                 <RefreshCw size={9} className={summaryLoading ? 'animate-spin' : ''} />
                 다시 분석
@@ -121,7 +137,7 @@ export function Dashboard() {
 
         {/* Genre distribution */}
         {stats.topGenres.length > 0 && (
-          <Section title="장르" icon={<Music2 size={13} className="text-violet-400" />}>
+          <Section title="장르" icon={<Music2 size={13} style={{ color: 'var(--color-amber-400)' }} />}>
             <div className="space-y-3">
               {stats.topGenres.map(({ genre, trackCount }) => (
                 <div key={genre}>
@@ -131,8 +147,11 @@ export function Dashboard() {
                   </div>
                   <div className="h-1.5 bg-neutral-800 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-violet-500 rounded-full transition-all duration-700"
-                      style={{ width: `${(trackCount / maxGenreCount) * 100}%` }}
+                      className="h-full rounded-full transition-all duration-700"
+                      style={{
+                        width: `${(trackCount / maxGenreCount) * 100}%`,
+                        background: 'var(--color-amber-500)',
+                      }}
                     />
                   </div>
                 </div>
@@ -143,7 +162,7 @@ export function Dashboard() {
 
         {/* Mood distribution */}
         {stats.topMoods.length > 0 && (
-          <Section title="무드" icon={<Zap size={13} className="text-blue-400" />}>
+          <Section title="무드" icon={<Zap size={13} style={{ color: 'var(--color-rose-400)' }} />}>
             <div className="space-y-3">
               {stats.topMoods.map(({ mood, trackCount }) => (
                 <div key={mood}>
@@ -153,8 +172,11 @@ export function Dashboard() {
                   </div>
                   <div className="h-1.5 bg-neutral-800 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-blue-500 rounded-full transition-all duration-700"
-                      style={{ width: `${(trackCount / maxMoodCount) * 100}%` }}
+                      className="h-full rounded-full transition-all duration-700"
+                      style={{
+                        width: `${(trackCount / maxMoodCount) * 100}%`,
+                        background: 'var(--color-rose-400)',
+                      }}
                     />
                   </div>
                 </div>
@@ -210,11 +232,11 @@ export function Dashboard() {
                         <p className="text-xs text-neutral-200 truncate leading-tight">{t.title ?? 'Unknown'}</p>
                         <div className="flex items-center gap-1.5">
                           {t.genre && (
-                            <span className="text-[9px] text-violet-400">{t.genre}</span>
+                            <span className="text-[9px]" style={{ color: 'var(--color-amber-400)' }}>{t.genre}</span>
                           )}
                           {t.genre && t.mood && <span className="text-[9px] text-neutral-700">·</span>}
                           {t.mood && (
-                            <span className="text-[9px] text-blue-400">{t.mood}</span>
+                            <span className="text-[9px]" style={{ color: 'var(--color-rose-400)' }}>{t.mood}</span>
                           )}
                         </div>
                       </div>

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -107,7 +107,7 @@ export function MainContent() {
               cancelled = true
               toast.dismiss(t.id)
             }}
-            className="text-violet-400 font-medium hover:text-violet-300"
+            className="text-amber-400 font-medium hover:text-amber-300"
           >
             실행 취소
           </button>
@@ -322,7 +322,7 @@ function TrackGrid({ tracks, selectedTrackId, onSelect, onPlay, onContextMenu }:
             onDoubleClick={() => onPlay(track)}
             onContextMenu={(e) => onContextMenu(e, track.id)}
             className={`flex flex-col items-start text-left group rounded-lg overflow-hidden p-1 transition-colors
-              ${isActive ? 'ring-2 ring-neutral-100 rounded-lg' : isSelected ? 'ring-2 ring-violet-500/60 rounded-lg' : 'hover:bg-neutral-800/60'}`}
+              ${isActive ? 'ring-2 ring-amber-400/80 rounded-lg' : isSelected ? 'ring-2 ring-amber-500/50 rounded-lg' : 'hover:bg-neutral-800/60'}`}
           >
             <div className="w-full aspect-square bg-neutral-800 relative overflow-hidden rounded-lg mb-2">
               {coverUrl ? (
@@ -348,16 +348,8 @@ function TrackGrid({ tracks, selectedTrackId, onSelect, onPlay, onContextMenu }:
             {/* Genre / Mood pills */}
             {(track.genre || track.mood) && (
               <div className="flex gap-1 flex-wrap px-0.5">
-                {track.genre && (
-                  <span className="text-[9px] px-1.5 py-0.5 bg-violet-500/20 text-violet-400 rounded-full leading-none">
-                    {track.genre}
-                  </span>
-                )}
-                {track.mood && (
-                  <span className="text-[9px] px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded-full leading-none">
-                    {track.mood}
-                  </span>
-                )}
+                {track.genre && <span className="pill-genre">{track.genre}</span>}
+                {track.mood && <span className="pill-mood">{track.mood}</span>}
               </div>
             )}
           </button>


### PR DESCRIPTION
## Summary

- **Dashboard**: Hero 그라디언트·장르·무드 progress bar·AI 버튼·로딩 dots의 `violet-*/indigo-*/blue-*` → amber/rose oklch 팔레트
- **MainContent**: 트랙 선택 링 `ring-violet-500` → `ring-amber-500`, 삭제 실행취소 버튼, pill 클래스 통일
- **ImportUrlDialog**: 플레이리스트 힌트 `blue-*` → `amber-*`, AI 진행 바 `violet-500` → `amber-500`
- **TrackMetadataPanel**: 편집 input focus ring `violet` → `amber`, AI 단계 텍스트 `text-violet-400` → `text-amber-400`

Studio Monitor 디자인 시스템(#22)의 amber(장르) + rose(무드) 팔레트를 앱 전역에 완전히 적용.

## Test plan

- [ ] 앱 실행 후 트랙 선택 시 amber 하이라이트 확인
- [ ] Dashboard 장르/무드 프로그레스 바 색상 확인 (amber/rose)
- [ ] ImportUrlDialog 열고 YouTube 플레이리스트 URL 입력 → amber 힌트 확인
- [ ] TrackMetadataPanel에서 편집 클릭 → amber focus ring 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)